### PR TITLE
Add Skill Self-Play

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ depending on **which component is improved** during learning and adaptation.
   | 2026 | Tool-R0: Self-Evolving LLM Agents for Tool-Learning from Zero Data | arXiv | [paper](https://arxiv.org/abs/2602.21320) | [code](https://github.com/emrecanacikgoz/Tool-R0) |
   | 2026 | Socratic-SWE: Self-Evolving Coding Agents via Trace-Derived Agent Skills | arXiv | [paper](https://arxiv.org/abs/2606.07412) | N/A |
   | 2026 | Self-evolving LLM Agents with In-Distribution Optimization | ICML | [paper](https://arxiv.org/abs/2606.07367) | N/A |
+  | 2026 | Skill Self-Play: Pushing the Frontier of LLM Capability with Co-Evolving Skills | arXiv | [paper](https://arxiv.org/abs/2607.22529) | [code](https://github.com/Qwen-Applications/skill-self-play) |
 
   </details>
 


### PR DESCRIPTION
This PR adds Skill Self-Play to **1.3.1 Interaction with Grounded Task Environments**.

Skill-SP generates tasks through self-play and uses executable validators and environment-grounded rewards to iteratively improve the proposer and solver through reinforcement learning.

Paper: https://arxiv.org/abs/2607.22529
Code: https://github.com/Qwen-Applications/skill-self-play