### PR TITLE
Add Ouroboros to Full Scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,6 +582,7 @@ depending on **which component is improved** during learning and adaptation.
   | 2026 | Continual Harness: Online Adaptation for Self-Improving Foundation Agents | arXiv | [paper](https://arxiv.org/abs/2605.09998) | [code](https://github.com/sethkarten/continual-harness) |
   | 2026 | The Red Queen Gödel Machine: Co-Evolving Agents and Their Evaluators | arXiv | [paper](https://arxiv.org/abs/2606.26294) | N/A |
   | 2026 | Harness-R1: Learning to Edit Executable Runtime Harnesses from Agent Failure Trajectories | arXiv | [paper](https://arxiv.org/abs/2608.02276) | [code](https://github.com/DeepExperience/Harness-R1) |
+  | 2026 | Ouroboros: A Self-Developing Frontier Coding Agent with Reviewed Core Evolution | arXiv | [paper](https://arxiv.org/abs/2608.08311) | [code](https://github.com/razzant/ouroboros) |
   
 </details>
 


### PR DESCRIPTION
This adds the Ouroboros technical report to Full Scaffolding. The paper follows a 161-day deployment in which the agent evolves its own harness through reviewed code changes, while benchmark campaigns use frozen system snapshots. Paper: https://arxiv.org/abs/2608.08311. Code: https://github.com/razzant/ouroboros.